### PR TITLE
fixing nconn_tls write EAGAIN handling to set poll properties to look…

### DIFF
--- a/examples/https_files.cc
+++ b/examples/https_files.cc
@@ -46,7 +46,7 @@ int main(int argc, char** argv)
         // -------------------------------------------------
         // defaults
         // -------------------------------------------------
-        ns_is2::trc_log_level_set(ns_is2::TRC_LOG_LEVEL_NONE);
+        ns_is2::trc_log_level_set(ns_is2::TRC_LOG_LEVEL_ERROR);
         char l_opt;
         std::string l_arg;
         int l_option_index = 0;
@@ -167,8 +167,8 @@ int main(int argc, char** argv)
         l_srvr->register_lsnr(l_lsnr);
         l_srvr->set_num_threads(0);
         l_srvr->run();
-        if(l_srvr) {delete l_srvr; l_srvr = NULL;}
-        if(l_file_h) {delete l_file_h; l_file_h = NULL;}
+        if (l_srvr) {delete l_srvr; l_srvr = NULL;}
+        if (l_file_h) {delete l_file_h; l_file_h = NULL;}
         return 0;
 }
 

--- a/examples/https_files.cc
+++ b/examples/https_files.cc
@@ -36,6 +36,7 @@ void print_usage(FILE* a_stream, int a_exit_code)
         fprintf(a_stream, "  -p, --port          port (default: 12345)\n");
         fprintf(a_stream, "  -k, --key           certificate key file\n");
         fprintf(a_stream, "  -c, --cert          public certificate file\n");
+        fprintf(a_stream, "  -b, --block_size    set block size for contiguous send/recv sizes\n");
         exit(a_exit_code);
 }
 //! ----------------------------------------------------------------------------
@@ -53,6 +54,7 @@ int main(int argc, char** argv)
         uint16_t l_port = 12345;
         std::string l_key;
         std::string l_cert;
+        uint32_t l_block_size = 4096;
         // -------------------------------------------------
         // options
         // -------------------------------------------------
@@ -63,13 +65,16 @@ int main(int argc, char** argv)
                 // -----------------------------------------
                 { "help",         0, 0, 'h' },
                 { "port",         1, 0, 'p' },
+                { "key",          1, 0, 'k' },
+                { "cert",         1, 0, 'c' },
+                { "block_size",   1, 0, 'b' },
                 // list sentinel
                 { 0, 0, 0, 0 }
         };
         // -------------------------------------------------
         // Args...
         // -------------------------------------------------
-        char l_short_arg_list[] = "hp:k:c:";
+        char l_short_arg_list[] = "hp:k:c:b:";
         while ((l_opt = getopt_long_only(argc, argv, l_short_arg_list, l_long_options, &l_option_index)) != -1)
         {
                 if (optarg)
@@ -129,6 +134,21 @@ int main(int argc, char** argv)
                         break;
                 }
                 // -----------------------------------------
+                // block_size
+                // -----------------------------------------
+                case 'b':
+                {
+                        int l_port_val;
+                        l_port_val = atoi(optarg);
+                        if ((l_port_val < 1))
+                        {
+                                printf("Error bad block size value: %d.\n", l_port_val);
+                                print_usage(stdout, STATUS_ERROR);
+                        }
+                        l_block_size = (uint32_t)l_port_val;
+                        break;
+                }
+                // -----------------------------------------
                 // What???
                 // -----------------------------------------
                 case '?':
@@ -164,6 +184,7 @@ int main(int argc, char** argv)
         ns_is2::srvr *l_srvr = new ns_is2::srvr();
         l_srvr->set_tls_server_ctx_key(l_key);
         l_srvr->set_tls_server_ctx_crt(l_cert);
+        l_srvr->set_block_size(l_block_size);
         l_srvr->register_lsnr(l_lsnr);
         l_srvr->set_num_threads(0);
         l_srvr->run();

--- a/include/is2/srvr/srvr.h
+++ b/include/is2/srvr/srvr.h
@@ -19,6 +19,10 @@
 #include "is2/nconn/conn_status.h"
 #include "is2/srvr/stat.h"
 //! ----------------------------------------------------------------------------
+//! constants
+//! ----------------------------------------------------------------------------
+#define _DEFAULT_NBQ_BLOCK_SIZE (4*1024)
+//! ----------------------------------------------------------------------------
 //! extern Fwd Decl's
 //! ----------------------------------------------------------------------------
 struct ssl_st;
@@ -70,6 +74,8 @@ public:
         void set_num_parallel(uint32_t a_num_parallel);
         void set_num_reqs_per_conn(int32_t a_num_reqs_per_conn);
         void set_stat_update_ms(uint32_t a_update_ms);
+        void set_block_size(uint32_t a_size) { m_block_size = a_size; }
+        uint32_t get_block_size(void) { return m_block_size; }
         void get_stat(t_stat_cntr_t &ao_stat, t_stat_calc_t &ao_calc_stat, bool a_no_cache=false);
         void display_stat(void);
         // Server name
@@ -136,6 +142,7 @@ private:
         std::string m_dns_ai_cache_file;
         t_srvr_list_t m_t_srvr_list;
         bool m_is_initd;
+        uint32_t m_block_size;
         // stats
         uint64_t m_start_time_ms;
         pthread_mutex_t m_stat_mutex;

--- a/src/evr/evr.cc
+++ b/src/evr/evr.cc
@@ -51,7 +51,7 @@ evr_loop::evr_loop(evr_loop_type_t a_type,
                 m_evr = new evr_epoll();
         }
 #endif
-        if(!m_evr)
+        if (!m_evr)
         {
                 //NDBG_PRINT("Using evr_select\n");
                 m_evr = new evr_select();
@@ -68,19 +68,19 @@ evr_loop::~evr_loop(void)
         while(!m_event_pq.empty())
         {
                 evr_event_t *l_timer = m_event_pq.top();
-                if(l_timer)
+                if (l_timer)
                 {
                         delete l_timer;
                         l_timer = NULL;
                 }
                 m_event_pq.pop();
         }
-        if(m_events)
+        if (m_events)
         {
                 free(m_events);
                 m_events = NULL;
         }
-        if(m_evr)
+        if (m_evr)
         {
                 delete m_evr;
                 m_evr = NULL;
@@ -103,14 +103,14 @@ uint32_t evr_loop::dequeue_events(void)
         {
                 uint64_t l_now_ms = get_time_ms();
                 l_event = m_event_pq.top();
-                if(!l_event ||
+                if (!l_event ||
                    (l_event->m_magic != EVR_EVENT_MAGIC))
                 {
                         TRC_ERROR("bad event -ignoring.\n");
                         m_event_pq.pop();
                         continue;
                 }
-                if(l_event->m_state == EVR_EVENT_CANCELLED)
+                if (l_event->m_state == EVR_EVENT_CANCELLED)
                 {
                         //NDBG_PRINT("%sDELETING%s TIMER: %p\n", ANSI_COLOR_FG_RED, ANSI_COLOR_OFF, l_timer);
                         m_event_pq.pop();
@@ -119,14 +119,14 @@ uint32_t evr_loop::dequeue_events(void)
                         continue;
                 }
                 uint64_t l_ev_time_ms = l_event->m_time_ms;
-                if(l_now_ms < l_ev_time_ms)
+                if (l_now_ms < l_ev_time_ms)
                 {
                         l_time_diff_ms = l_ev_time_ms - l_now_ms;
                         break;
                 }
                 // remove -service event
                 m_event_pq.pop();
-                if(l_event->m_cb)
+                if (l_event->m_cb)
                 {
                         //NDBG_PRINT("%sRUNNING_%s TIMER: %p at %lu ms\n",ANSI_COLOR_FG_YELLOW, ANSI_COLOR_OFF,l_event,l_now_ms);
                         int32_t l_s;
@@ -158,12 +158,12 @@ int32_t evr_loop::run(void)
         //NDBG_PRINT("%sWAIT4_CONNECTIONS%s: l_time_diff_ms = %d\n", ANSI_COLOR_FG_RED, ANSI_COLOR_OFF, l_time_diff_ms);
         l_num_events = m_evr->wait(m_events, m_max_events, l_time_diff_ms);
         //NDBG_PRINT("%sSTART_CONNECTIONS%s: l_num_events = %d\n", ANSI_COLOR_FG_MAGENTA, ANSI_COLOR_OFF, l_num_events);
-        if(l_num_events < 0)
+        if (l_num_events < 0)
         {
                 TRC_ERROR("performing wait.\n");
                 return STATUS_ERROR;
         }
-        else if(l_num_events == 0)
+        else if (l_num_events == 0)
         {
                 // dequeue any pending timeouts
                 l_time_diff_ms = dequeue_events();
@@ -184,7 +184,7 @@ int32_t evr_loop::run(void)
                 // -----------------------------------------
                 // Validity checks
                 // -----------------------------------------
-                if(!l_evr_fd ||
+                if (!l_evr_fd ||
                    (l_evr_fd->m_magic != EVR_EVENT_FD_MAGIC))
                 {
                         TRC_ERROR("bad event -ignoring.\n");
@@ -193,33 +193,33 @@ int32_t evr_loop::run(void)
                 // -----------------------------------------
                 // in
                 // -----------------------------------------
-                if(l_events & EVR_EV_VAL_READABLE)
+                if (l_events & EVR_EV_VAL_READABLE)
                 {
-                        if(l_evr_fd->m_read_cb &&
+                        if (l_evr_fd->m_read_cb &&
                           (l_evr_fd->m_attr_mask & EVR_FILE_ATTR_VAL_READABLE))
                         {
                                 int32_t l_status;
                                 //NDBG_PRINT("%sEVENTS%s: %s%sREAD%s\n", ANSI_COLOR_FG_CYAN, ANSI_COLOR_OFF, ANSI_COLOR_FG_RED, ANSI_COLOR_BG_WHITE, ANSI_COLOR_OFF);
                                 l_status = l_evr_fd->m_read_cb(l_evr_fd->m_data);
-                                if(l_status == STATUS_DONE)
+                                if (l_status == STATUS_DONE)
                                 {
                                         // Skip handling more events for this fd
                                         continue;
                                 }
-                                if(l_status != STATUS_OK)
+                                if (l_status != STATUS_OK)
                                 {
                                         TRC_ERROR("performing read_cb\n");
                                         // Skip handling more events for this fd
                                         continue;
                                 }
                         }
-                        if(l_events & EVR_EV_HUP)
+                        if (l_events & EVR_EV_HUP)
                         {
                                 // Skip handling more events for this fd
                                 //TRC_ERROR("EVR_EV_HUP\n");
                                 //continue;
                         }
-                        if(l_events & EVR_EV_ERR)
+                        if (l_events & EVR_EV_ERR)
                         {
                                 // Skip handling more events for this fd
                                 TRC_ERROR("EVR_EV_ERR\n");
@@ -229,20 +229,20 @@ int32_t evr_loop::run(void)
                 // -----------------------------------------
                 // out
                 // -----------------------------------------
-                if(l_events & EVR_EV_VAL_WRITEABLE)
+                if (l_events & EVR_EV_VAL_WRITEABLE)
                 {
-                        if(l_evr_fd->m_write_cb &&
+                        if (l_evr_fd->m_write_cb &&
                           (l_evr_fd->m_attr_mask & EVR_FILE_ATTR_VAL_WRITEABLE))
                         {
                                 int32_t l_status;
                                 //NDBG_PRINT("%sEVENTS%s: %s%sWRITE%s\n", ANSI_COLOR_FG_CYAN, ANSI_COLOR_OFF, ANSI_COLOR_FG_BLUE, ANSI_COLOR_BG_WHITE, ANSI_COLOR_OFF);
                                 l_status = l_evr_fd->m_write_cb(l_evr_fd->m_data);
-                                if(l_status == STATUS_DONE)
+                                if (l_status == STATUS_DONE)
                                 {
                                         // Skip handling more events for this fd
                                         continue;
                                 }
-                                if(l_status != STATUS_OK)
+                                if (l_status != STATUS_OK)
                                 {
                                         TRC_ERROR("performing write_cb\n");
                                         // Skip handling more events for this fd
@@ -258,20 +258,20 @@ int32_t evr_loop::run(void)
                 // by read callbacks
                 // -----------------------------------------
                 //uint32_t l_other_events = l_events & (~(EPOLLIN | EPOLLOUT));
-                //if(l_events & EPOLLRDHUP)
-                //if(l_events & EPOLLERR)
-                //if(0)
+                //if (l_events & EPOLLRDHUP)
+                //if (l_events & EPOLLERR)
+                //if (0)
                 //{
-                //        if(l_evr_event->m_error_cb)
+                //        if (l_evr_event->m_error_cb)
                 //        {
                 //                int32_t l_status = STATUS_OK;
                 //                l_status = l_evr_event->m_error_cb(l_evr_event->m_data);
-                //                if(l_status == STATUS_DONE)
+                //                if (l_status == STATUS_DONE)
                 //                {
                 //                        // Skip handling more events for this fd
                 //                        continue;
                 //                }
-                //                if(l_status != STATUS_OK)
+                //                if (l_status != STATUS_OK)
                 //                {
                 //                        //NDBG_PRINT("Error: l_status: %d\n", l_status);
                 //                        // Skip handling more events for this fd
@@ -289,7 +289,7 @@ int32_t evr_loop::run(void)
 //! ----------------------------------------------------------------------------
 int32_t evr_loop::add_fd(int a_fd, uint32_t a_attr_mask, evr_fd_t *a_evr_fd_event)
 {
-        if(!a_evr_fd_event)
+        if (!a_evr_fd_event)
         {
                 return STATUS_ERROR;
         }
@@ -306,7 +306,7 @@ int32_t evr_loop::add_fd(int a_fd, uint32_t a_attr_mask, evr_fd_t *a_evr_fd_even
 //! ----------------------------------------------------------------------------
 int32_t evr_loop::mod_fd(int a_fd, uint32_t a_attr_mask, evr_fd_t *a_evr_fd_event)
 {
-        if(!a_evr_fd_event)
+        if (!a_evr_fd_event)
         {
                 return STATUS_ERROR;
         }
@@ -323,7 +323,7 @@ int32_t evr_loop::mod_fd(int a_fd, uint32_t a_attr_mask, evr_fd_t *a_evr_fd_even
 //! ----------------------------------------------------------------------------
 int32_t evr_loop::del_fd(int a_fd)
 {
-        if(!m_evr)
+        if (!m_evr)
         {
                 return STATUS_OK;
         }
@@ -365,7 +365,7 @@ int32_t evr_loop::cancel_event(evr_event_t *a_event)
         //NDBG_PRINT("%sCANCEL__%s TIMER: %p\n",ANSI_COLOR_BG_RED, ANSI_COLOR_OFF,a_timer);
         //NDBG_PRINT_BT();
         // TODO synchronization???
-        if(a_event)
+        if (a_event)
         {
                 //printf("%sXXX%s: %p TIMER AT %24lu ms --> %24lu\n",ANSI_COLOR_FG_RED, ANSI_COLOR_OFF,a_timer,0,l_timer_event->m_time_ms);
                 a_event->m_cb = NULL;
@@ -387,7 +387,7 @@ int32_t evr_loop::cancel_event(evr_event_t *a_event)
 int32_t evr_loop::signal(void)
 {
         //NDBG_PRINT("%sSIGNAL%s\n", ANSI_COLOR_BG_RED, ANSI_COLOR_OFF);
-        if(!m_evr)
+        if (!m_evr)
         {
                 return STATUS_ERROR;
         }

--- a/src/evr/evr_epoll.cc
+++ b/src/evr/evr_epoll.cc
@@ -33,14 +33,14 @@ evr_epoll::evr_epoll(void):
         //NDBG_PRINT("%sCREATE_EPOLL%s: a_max_events = %d\n",
         //           ANSI_COLOR_BG_MAGENTA, ANSI_COLOR_OFF, a_max_connections);
         m_fd = epoll_create1(0);
-        if(m_fd == -1)
+        if (m_fd == -1)
         {
                 TRC_ERROR("epoll_create() failed: %s\n", strerror(errno));
                 exit(-1);
         }
         // Create ctrl fd
         m_ctrl_fd = eventfd(0, EFD_NONBLOCK);
-        if(m_ctrl_fd == -1)
+        if (m_ctrl_fd == -1)
         {
                 TRC_ERROR("eventfd() failed: %s\n", strerror(errno));
                 exit(-1);
@@ -48,7 +48,7 @@ evr_epoll::evr_epoll(void):
         
         int32_t l_status = 0;
         l_status = add(m_ctrl_fd, EVR_FILE_ATTR_MASK_READ|EVR_FILE_ATTR_MASK_ET, NULL);
-        if(l_status != 0)
+        if (l_status != 0)
         {
                 TRC_ERROR("failed to add ctrl fd.\n");
                 exit(-1);
@@ -77,7 +77,7 @@ int evr_epoll::wait(evr_events_t* a_ev, int a_max_events, int a_timeout_msec)
         //NDBG_PRINT("%swait%s = %d\n",
         //           ANSI_COLOR_BG_YELLOW, ANSI_COLOR_OFF,
         //           l_s);
-        if(l_s < 0)
+        if (l_s < 0)
         {
                 NDBG_PRINT("error: reason[%d] EINTR: %d: %s\n", errno, EINTR, strerror(errno));
         }
@@ -91,12 +91,12 @@ int evr_epoll::wait(evr_events_t* a_ev, int a_max_events, int a_timeout_msec)
 static inline uint32_t get_epoll_attr(uint32_t a_attr_mask)
 {
         uint32_t l_attr = 0;
-        if(a_attr_mask & EVR_FILE_ATTR_MASK_READ)         l_attr |= EPOLLIN;
-        if(a_attr_mask & EVR_FILE_ATTR_MASK_WRITE)        l_attr |= EPOLLOUT;
-        if(a_attr_mask & EVR_FILE_ATTR_MASK_STATUS_ERROR) l_attr |= EPOLLERR;
-        if(a_attr_mask & EVR_FILE_ATTR_MASK_RD_HUP)       l_attr |= EPOLLRDHUP;
-        if(a_attr_mask & EVR_FILE_ATTR_MASK_HUP)          l_attr |= EPOLLRDHUP;
-        if(a_attr_mask & EVR_FILE_ATTR_MASK_ET)           l_attr |= EPOLLET;
+        if (a_attr_mask & EVR_FILE_ATTR_MASK_READ)         l_attr |= EPOLLIN;
+        if (a_attr_mask & EVR_FILE_ATTR_MASK_WRITE)        l_attr |= EPOLLOUT;
+        if (a_attr_mask & EVR_FILE_ATTR_MASK_STATUS_ERROR) l_attr |= EPOLLERR;
+        if (a_attr_mask & EVR_FILE_ATTR_MASK_RD_HUP)       l_attr |= EPOLLRDHUP;
+        if (a_attr_mask & EVR_FILE_ATTR_MASK_HUP)          l_attr |= EPOLLRDHUP;
+        if (a_attr_mask & EVR_FILE_ATTR_MASK_ET)           l_attr |= EPOLLET;
         return l_attr;
 }
 //! ----------------------------------------------------------------------------
@@ -113,7 +113,7 @@ int evr_epoll::add(int a_fd, uint32_t a_attr_mask, evr_fd_t *a_evr_fd_event)
         struct epoll_event ev;
         ev.events = get_epoll_attr(a_attr_mask);
         ev.data.ptr = a_evr_fd_event;
-        if(0 != epoll_ctl(m_fd, EPOLL_CTL_ADD, a_fd, &ev))
+        if (0 != epoll_ctl(m_fd, EPOLL_CTL_ADD, a_fd, &ev))
         {
                 //NDBG_PRINT("Error: epoll_fd[%d] EPOLL_CTL_ADD fd[%d] failed (%s)\n",
                 //           m_fd, a_fd, strerror(errno));
@@ -132,10 +132,10 @@ int evr_epoll::mod(int a_fd, uint32_t a_attr_mask, evr_fd_t *a_evr_fd_event)
         //           ANSI_COLOR_BG_GREEN, ANSI_COLOR_OFF,
         //           a_fd, a_attr_mask);
         //NDBG_PRINT_BT();
-        struct epoll_event ev;
-        ev.events = get_epoll_attr(a_attr_mask);
-        ev.data.ptr = a_evr_fd_event;
-        if(0 != epoll_ctl(m_fd, EPOLL_CTL_MOD, a_fd, &ev))
+        struct epoll_event l_ev;
+        l_ev.events = get_epoll_attr(a_attr_mask);
+        l_ev.data.ptr = a_evr_fd_event;
+        if (0 != epoll_ctl(m_fd, EPOLL_CTL_MOD, a_fd, &l_ev))
         {
                 TRC_ERROR("epoll_fd[%d] EPOLL_CTL_MOD fd[%d] failed (%s)\n",
                            m_fd, a_fd, strerror(errno));
@@ -153,9 +153,9 @@ int evr_epoll::del(int a_fd)
         // TODO Can skip del for close(fd) -since is removed automagically
         //NDBG_PRINT("%sdel%s: fd: %d\n", ANSI_COLOR_BG_RED, ANSI_COLOR_OFF, a_fd);
         struct epoll_event ev;
-        if((m_fd > 0) && (a_fd > 0))
+        if ((m_fd > 0) && (a_fd > 0))
         {
-                if(0 != epoll_ctl(m_fd, EPOLL_CTL_DEL, a_fd, &ev))
+                if (0 != epoll_ctl(m_fd, EPOLL_CTL_DEL, a_fd, &ev))
                 {
                         TRC_ERROR("epoll_fd[%d] EPOLL_CTL_DEL fd[%d] failed (%s)\n",
                                    m_fd, a_fd, strerror(errno));
@@ -176,7 +176,7 @@ int32_t evr_epoll::signal(void)
         ssize_t l_write_status = 0;
         //NDBG_PRINT("WRITING m_ctrl_fd: %d\n", m_ctrl_fd);
         l_write_status = write(m_ctrl_fd, &l_value, sizeof (l_value));
-        if(l_write_status == -1)
+        if (l_write_status == -1)
         {
                 //NDBG_PRINT("l_write_status: %ld\n", l_write_status);
                 return STATUS_ERROR;

--- a/src/handler/file/file_h.cc
+++ b/src/handler/file/file_h.cc
@@ -27,6 +27,10 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+//! ----------------------------------------------------------------------------
+//! constants
+//! ----------------------------------------------------------------------------
+#define _FILE_MAX_READ_PER_BYTES (64*1024)
 namespace ns_is2 {
 //! ----------------------------------------------------------------------------
 //! \details: TODO
@@ -204,7 +208,7 @@ h_resp_t file_h::get_file(session &a_session,
         // -------------------------------------------------
         // Read up to 64k
         // -------------------------------------------------
-        uint32_t l_read = 64*1024;
+        uint32_t l_read = _FILE_MAX_READ_PER_BYTES;
         if (l_read - l_q.read_avail() > 0)
         {
                 l_read = l_read - l_q.read_avail();

--- a/src/handler/file/file_h.cc
+++ b/src/handler/file/file_h.cc
@@ -67,14 +67,14 @@ h_resp_t file_h::do_get(session &a_session, rqst &a_rqst, const url_pmap_t &a_ur
         l_s = get_path(l_path,
                        m_route,
                        l_url_path_str);
-        if(l_s != STATUS_OK)
+        if (l_s != STATUS_OK)
         {
                 return H_RESP_CLIENT_ERROR;
         }
-        if(l_path.empty() ||
+        if (l_path.empty() ||
           (l_path == "/"))
         {
-                if(!m_index.empty())
+                if (!m_index.empty())
                 {
                         l_path = "/" + m_index;
                 }
@@ -83,7 +83,7 @@ h_resp_t file_h::do_get(session &a_session, rqst &a_rqst, const url_pmap_t &a_ur
                         return H_RESP_CLIENT_ERROR;
                 }
         }
-        if(!m_root.empty())
+        if (!m_root.empty())
         {
                 l_path = m_root + l_path;
         }
@@ -132,10 +132,10 @@ h_resp_t file_h::get_file(session &a_session,
                           rqst &a_rqst,
                           const std::string &a_path)
 {
-        if(!a_session.m_out_q)
+        if (!a_session.m_out_q)
         {
                 a_session.m_out_q = a_session.m_t_srvr.get_nbq(NULL);
-                if(!a_session.m_out_q)
+                if (!a_session.m_out_q)
                 {
                         TRC_ERROR("a_session.m_out_q\n");
                         return send_internal_server_error(a_session, a_rqst.m_supports_keep_alives);
@@ -145,7 +145,7 @@ h_resp_t file_h::get_file(session &a_session,
         file_u *l_fs = new file_u(a_session);
         int32_t l_s;
         l_s = l_fs->fsinit(a_path.c_str());
-        if(l_s != STATUS_OK)
+        if (l_s != STATUS_OK)
         {
                 delete l_fs;
                 l_fs = NULL;
@@ -163,7 +163,7 @@ h_resp_t file_h::get_file(session &a_session,
         // Get extension
         std::string l_ext = get_file_ext(a_path);
         mime_types::ext_type_map_t::const_iterator i_m = mime_types::S_EXT_TYPE_MAP.find(l_ext);
-        if(i_m != mime_types::S_EXT_TYPE_MAP.end())
+        if (i_m != mime_types::S_EXT_TYPE_MAP.end())
         {
                 nbq_write_header(l_q, "Content-type", i_m->second.c_str());
         }
@@ -176,7 +176,7 @@ h_resp_t file_h::get_file(session &a_session,
         nbq_write_header(l_q, "Content-Length", l_length_str);
         // TODO get last modified for file...
         nbq_write_header(l_q, "Last-Modified", get_date_str());
-        if(a_rqst.m_supports_keep_alives)
+        if (a_rqst.m_supports_keep_alives)
         {
                 nbq_write_header(l_q, "Connection", "keep-alive");
         }
@@ -188,13 +188,13 @@ h_resp_t file_h::get_file(session &a_session,
         // -------------------------------------------------
         // check for zero bytes
         // -------------------------------------------------
-        if(l_fs->fssize() <= 0)
+        if (l_fs->fssize() <= 0)
         {
                 // all done; close the file.
                 l_fs->set_ups_done();
                 int32_t l_s;
                 l_s = a_session.queue_output();
-                if(l_s != STATUS_OK)
+                if (l_s != STATUS_OK)
                 {
                         TRC_ERROR("performing queue_output\n");
                         return H_RESP_SERVER_ERROR;
@@ -205,17 +205,17 @@ h_resp_t file_h::get_file(session &a_session,
         // Read up to 64k
         // -------------------------------------------------
         uint32_t l_read = 64*1024;
-        if(l_read - l_q.read_avail() > 0)
+        if (l_read - l_q.read_avail() > 0)
         {
                 l_read = l_read - l_q.read_avail();
         }
-        if(l_fs->fssize() < l_read)
+        if (l_fs->fssize() < l_read)
         {
                 l_read = l_fs->fssize();
         }
         ssize_t l_ups_read_s;
         l_ups_read_s = l_fs->ups_read_ahead(l_read);
-        if(l_ups_read_s < 0)
+        if (l_ups_read_s < 0)
         {
                 TRC_ERROR("performing ups_read\n");
         }
@@ -243,7 +243,7 @@ file_u::file_u(session &a_session):
 //! ----------------------------------------------------------------------------
 file_u::~file_u()
 {
-        if(m_fd > 0)
+        if (m_fd > 0)
         {
                 close(m_fd);
                 m_fd = -1;
@@ -271,10 +271,10 @@ int32_t file_u::fsinit(const char *a_filename)
         }
         struct stat l_stat;
         l_s = fstat(m_fd, &l_stat);
-        if(l_s != 0)
+        if (l_s != 0)
         {
                 TRC_ERROR("performing stat on file: %s.  Reason: %s\n", a_filename, strerror(errno));
-                if(m_fd > 0)
+                if (m_fd > 0)
                 {
                         close(m_fd);
                         m_fd = -1;
@@ -282,10 +282,10 @@ int32_t file_u::fsinit(const char *a_filename)
                 return STATUS_ERROR;
         }
         // Check if is regular file
-        if(!(l_stat.st_mode & S_IFREG))
+        if (!(l_stat.st_mode & S_IFREG))
         {
                 TRC_ERROR("opening file: %s.  Reason: is NOT a regular file\n", a_filename);
-                if(m_fd > 0)
+                if (m_fd > 0)
                 {
                         close(m_fd);
                         m_fd = -1;
@@ -318,12 +318,12 @@ ssize_t file_u::ups_read(char *ao_dst, size_t a_len)
                 m_state = DONE;
                 return 0;
         }
-        else if(l_read < 0)
+        else if (l_read < 0)
         {
                 //NDBG_PRINT("Error performing read. Reason: %s\n", strerror(errno));
                 return STATUS_ERROR;
         }
-        if(l_read > 0)
+        if (l_read > 0)
         {
                 m_read += l_read;
         }
@@ -347,12 +347,12 @@ ssize_t file_u::ups_read(size_t a_len)
 //! ----------------------------------------------------------------------------
 ssize_t file_u::ups_read_ahead(size_t a_len)
 {
-        if(m_fd < 0)
+        if (m_fd < 0)
         {
                 return 0;
         }
         m_state = UPS_STATE_SENDING;
-        if(!(m_session.m_out_q))
+        if (!(m_session.m_out_q))
         {
                 TRC_ERROR("m_session->m_out_q == NULL\n");
                 return STATUS_ERROR;
@@ -362,7 +362,7 @@ ssize_t file_u::ups_read_ahead(size_t a_len)
         ssize_t l_last;
         size_t l_len_read = (a_len > (m_size - m_read))?(m_size - m_read): a_len;
         l_read = m_session.m_out_q->write_fd(m_fd, l_len_read, l_last);
-        if(l_read < 0)
+        if (l_read < 0)
         {
                 TRC_ERROR("performing read. Reason: %s\n", strerror(errno));
                 return STATUS_ERROR;
@@ -376,11 +376,11 @@ ssize_t file_u::ups_read_ahead(size_t a_len)
                 m_fd = -1;
                 m_state = UPS_STATE_DONE;
         }
-        if(l_read > 0)
+        if (l_read > 0)
         {
                 int32_t l_s;
                 l_s = m_session.queue_output();
-                if(l_s != STATUS_OK)
+                if (l_s != STATUS_OK)
                 {
                         TRC_ERROR("performing queue_output\n");
                         return STATUS_ERROR;
@@ -395,7 +395,7 @@ ssize_t file_u::ups_read_ahead(size_t a_len)
 //! ----------------------------------------------------------------------------
 int32_t file_u::ups_cancel(void)
 {
-        if(m_fd > 0)
+        if (m_fd > 0)
         {
                 close(m_fd);
                 m_state = UPS_STATE_DONE;

--- a/src/nconn/nconn.cc
+++ b/src/nconn/nconn.cc
@@ -8,7 +8,7 @@
 //! Please refer to the LICENSE file in the project root for the terms.
 //! ----------------------------------------------------------------------------
 //! ----------------------------------------------------------------------------
-//! Includes
+//! includes
 //! ----------------------------------------------------------------------------
 #include "is2/support/ndebug.h"
 #include "is2/nconn/nconn.h"
@@ -33,7 +33,6 @@ void* nconn::s_ssl_accept_ctx = NULL;
 //! ----------------------------------------------------------------------------
 int32_t nconn::nc_read(nbq *a_in_q, char **ao_buf, uint32_t &ao_read)
 {
-        //NDBG_PRINT("%sTRY_READ%s: a_in_q: %p\n", ANSI_COLOR_BG_RED, ANSI_COLOR_OFF, a_in_q);
         ao_read = 0;
         if (!a_in_q)
         {
@@ -57,7 +56,6 @@ int32_t nconn::nc_read(nbq *a_in_q, char **ao_buf, uint32_t &ao_read)
                 int32_t l_s = a_in_q->b_write_add_avail();
                 if (l_s <= 0)
                 {
-                        //NDBG_PRINT("Error performing b_write_add_avail\n");
                         return NC_STATUS_ERROR;
                 }
         }
@@ -70,19 +68,8 @@ int32_t nconn::nc_read(nbq *a_in_q, char **ao_buf, uint32_t &ao_read)
         {
                 l_read_size = a_in_q->b_write_avail();
         }
-        //NDBG_PRINT("%sTRY_READ%s: l_read_size: %d\n", ANSI_COLOR_BG_RED, ANSI_COLOR_OFF, l_read_size);
         char *l_buf = a_in_q->b_write_ptr();
-        //NDBG_PRINT("%sTRY_READ%s: m_out_q->read_ptr(): %p l_read_size: %d\n",
-        //                ANSI_COLOR_FG_RED, ANSI_COLOR_OFF,
-        //                l_buf,
-        //                l_read_size);
         l_s = ncread(l_buf, l_read_size);
-        //NDBG_PRINT("%sTRY_READ%s: l_bytes_read: %d\n", ANSI_COLOR_FG_RED, ANSI_COLOR_OFF, l_s);
-        //NDBG_PRINT("%sTRY_READ%s: l_bytes_read: %d old_size: %d-error:%d: %s\n",
-        //                ANSI_COLOR_FG_RED, ANSI_COLOR_OFF,
-        //                l_s,
-        //                (int)a_in_q->read_avail(),
-        //                errno, strerror(errno));
         if (l_s < 0)
         {
                 switch(l_s)
@@ -108,7 +95,6 @@ int32_t nconn::nc_read(nbq *a_in_q, char **ao_buf, uint32_t &ao_read)
                 return l_s;
         }
         ao_read += l_s;
-        //mem_display((uint8_t *)(l_buf), l_bytes_read);
         *ao_buf = l_buf;
         a_in_q->b_write_incr(l_s);
         return NC_STATUS_OK;
@@ -120,7 +106,6 @@ int32_t nconn::nc_read(nbq *a_in_q, char **ao_buf, uint32_t &ao_read)
 //! ----------------------------------------------------------------------------
 int32_t nconn::nc_write(nbq *a_out_q, uint32_t &ao_written)
 {
-        //NDBG_PRINT("%sTRY_WRITE%s: m_out_q: %p\n", ANSI_COLOR_BG_GREEN, ANSI_COLOR_OFF, a_out_q);
         ao_written = 0;
         if (!a_out_q)
         {
@@ -129,7 +114,6 @@ int32_t nconn::nc_write(nbq *a_out_q, uint32_t &ao_written)
         }
         if (!a_out_q->read_avail())
         {
-                //TRC_ERROR("Error a_out_q->read_avail() == 0\n");
                 return NC_STATUS_OK;
         }
         // -------------------------------------------------
@@ -139,12 +123,7 @@ int32_t nconn::nc_write(nbq *a_out_q, uint32_t &ao_written)
         //     add
         // -------------------------------------------------
         int32_t l_s;
-        //NDBG_PRINT("%sTRY_WRITE%s: m_out_q->b_read_ptr(): %p m_out_q->b_read_avail(): %d\n",
-        //                ANSI_COLOR_FG_GREEN, ANSI_COLOR_OFF,
-        //                a_out_q->b_read_ptr(),
-        //                a_out_q->b_read_avail());
         l_s = ncwrite(a_out_q->b_read_ptr(), a_out_q->b_read_avail());
-        //NDBG_PRINT("%sTRY_WRITE%s: l_bytes_written: %d\n", ANSI_COLOR_FG_GREEN, ANSI_COLOR_OFF, l_s);
         if (l_s < 0)
         {
                 switch(l_s)
@@ -155,7 +134,6 @@ int32_t nconn::nc_write(nbq *a_out_q, uint32_t &ao_written)
                 }
                 default:
                 {
-                        //NDBG_PRINT("Error performing ncwrite: status: %d\n", l_bytes_written);
                         return NC_STATUS_ERROR;
                 }
                 }
@@ -180,7 +158,6 @@ int32_t nconn::nc_write(nbq *a_out_q, uint32_t &ao_written)
 //! ----------------------------------------------------------------------------
 bool nconn::can_reuse(void)
 {
-        //NDBG_PRINT("CONN ka num %ld / %ld \n", m_num_reqs, m_num_reqs_per_conn);
         if (((m_num_reqs_per_conn == -1) ||
             (m_num_reqs < m_num_reqs_per_conn)))
         {
@@ -188,9 +165,6 @@ bool nconn::can_reuse(void)
         }
         else
         {
-                //NDBG_PRINT("CONN m_num_reqs: %ld m_num_reqs_per_conn: %ld \n",
-                //                m_num_reqs,
-                //                m_num_reqs_per_conn);
                 return false;
         }
 }
@@ -201,7 +175,6 @@ bool nconn::can_reuse(void)
 //! ----------------------------------------------------------------------------
 int32_t nconn::nc_set_listening(int32_t a_val)
 {
-        //NDBG_PRINT("%sRUN_STATE_MACHINE%s: SET_LISTENING[%d]\n", ANSI_COLOR_BG_RED, ANSI_COLOR_OFF, a_val);
         int32_t l_s;
         l_s = ncset_listening(a_val);
         if (l_s != NC_STATUS_OK)
@@ -218,7 +191,6 @@ int32_t nconn::nc_set_listening(int32_t a_val)
 //! ----------------------------------------------------------------------------
 int32_t nconn::nc_set_listening_nb(int32_t a_val)
 {
-        //NDBG_PRINT("%sRUN_STATE_MACHINE%s: SET_LISTENING[%d]\n", ANSI_COLOR_BG_RED, ANSI_COLOR_OFF, a_val);
         int32_t l_s;
         l_s = ncset_listening_nb(a_val);
         if (l_s != NC_STATUS_OK)
@@ -267,12 +239,6 @@ int32_t nconn::nc_set_connected(void)
 //! ----------------------------------------------------------------------------
 int32_t nconn::nc_cleanup()
 {
-        //NDBG_PRINT("%s--CONN--%s[%s] last_state: %d this: %p\n",
-        //                ANSI_COLOR_BG_RED, ANSI_COLOR_OFF,
-        //                m_label.c_str(),
-        //                m_nc_state,
-        //                this);
-        //NDBG_PRINT_BT();
         TRC_VERBOSE("tearing down: label: %s\n", m_label.c_str());
         int32_t l_s;
         l_s = nccleanup();
@@ -317,7 +283,6 @@ nconn::nconn(void):
       m_alpn_buf_len(0),
       m_timer_obj(NULL)
 {
-        //NDBG_PRINT("%s--CONN--%s last_state: %d this: %p\n", ANSI_COLOR_FG_GREEN, ANSI_COLOR_OFF, m_nc_state, this);
 }
 //! ----------------------------------------------------------------------------
 //! \details: TODO
@@ -326,7 +291,6 @@ nconn::nconn(void):
 //! ----------------------------------------------------------------------------
 nconn::~nconn(void)
 {
-        //NDBG_PRINT("%s--CONN--%s last_state: %d this: %p\n", ANSI_COLOR_FG_RED, ANSI_COLOR_OFF, m_nc_state, this);
         if (m_alpn_buf)
         {
                 free(m_alpn_buf);

--- a/src/srvr/srvr.cc
+++ b/src/srvr/srvr.cc
@@ -43,6 +43,7 @@ srvr::srvr(void):
         m_dns_ai_cache_file(NRESOLVER_DEFAULT_AI_CACHE_FILE),
         m_t_srvr_list(),
         m_is_initd(false),
+        m_block_size(_DEFAULT_NBQ_BLOCK_SIZE),
         m_start_time_ms(0),
         m_stat_mutex(),
         m_stat_update_ms(S_STAT_UPDATE_MS_DEFAULT),

--- a/src/srvr/t_srvr.cc
+++ b/src/srvr/t_srvr.cc
@@ -22,6 +22,7 @@
 #include "is2/support/nbq.h"
 #include "is2/status.h"
 #include "is2/support/trace.h"
+#include "is2/srvr/srvr.h"
 #include "is2/srvr/resp.h"
 #include "is2/srvr/lsnr.h"
 #include "is2/srvr/session.h"
@@ -427,9 +428,14 @@ void *t_srvr::t_run(void *a_nothing)
 //! ----------------------------------------------------------------------------
 nbq *t_srvr::get_nbq(nbq *a_nbq)
 {
+        uint32_t l_b_size = _DEFAULT_NBQ_BLOCK_SIZE;
+        if (m_srvr)
+        {
+                l_b_size = m_srvr->get_block_size();
+        }
         UNUSED(a_nbq);
         nbq *l_nbq = NULL;
-        l_nbq = new nbq(4*1024);
+        l_nbq = new nbq(l_b_size);
         return l_nbq;
 }
 //! ----------------------------------------------------------------------------


### PR DESCRIPTION
### What
- Fix `O_NONBLOCK` handling with `SSL_write` call to set `poll` to respond to `WRITEABLE` events if `EAGAIN`.
- Adding programmable send/recv buffer sizes.